### PR TITLE
Refactor code

### DIFF
--- a/OctoCmd/ContentView.swift
+++ b/OctoCmd/ContentView.swift
@@ -71,7 +71,6 @@ struct ContentView: View {
         }
         .padding(0)
         .frame(width: 320, height: 500)
-        
     }
 }
 

--- a/OctoCmd/MainApp.swift
+++ b/OctoCmd/MainApp.swift
@@ -25,7 +25,7 @@ struct MainApp: App {
     }
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate {
     let sharedData = SharedData()
     
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/OctoCmd/SharedData.swift
+++ b/OctoCmd/SharedData.swift
@@ -17,10 +17,13 @@ extension Sequence where Element: Hashable {
 
 struct WindowDef: Identifiable, Hashable {
     let id = UUID()
-    var hashValue: Int { get { return pid.hashValue }}
     var name = ""
     var wid = -1
     var pid = -1
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(pid)
+    }
 }
 
 func ==(left: WindowDef, right: WindowDef) -> Bool {
@@ -41,7 +44,7 @@ func getWindowsList() -> [WindowDef] {
     }.uniqued()
 }
 
-class SharedData: ObservableObject {
+final class SharedData: ObservableObject {
     @Published var ignored: [Int] = (UserDefaults.standard.array(forKey: "octoCmd_Ignored") as? [Int] ?? [])
     @Published var windows: [WindowDef] = getWindowsList()
     @Published var lastPid = -1


### PR DESCRIPTION
1. Use hash(into:) to fix deprecate
2. Use final for classes that do not have child classes